### PR TITLE
Déplacer l'(des)installation des paquets vers postinstall

### DIFF
--- a/ubuntu-et-variantes-integrdom.sh
+++ b/ubuntu-et-variantes-integrdom.sh
@@ -303,16 +303,6 @@ if [ "$(which mdm)" = "/usr/sbin/mdm" ] ; then # si MDM est installé (donc Mint
   wget --no-check-certificate https://raw.githubusercontent.com/dane-lyon/fichier-de-config/master/mdm.conf ; mv -f mdm.conf /etc/mdm/ ; 
 fi
 
-# Spécifique a Ubuntu Mate
-if [ "$(which caja)" = "/usr/bin/caja" ] ; then
-  apt-get -y purge hexchat transmission-gtk ubuntu-mate-welcome cheese pidgin rhythmbox ;
-fi
-
-# Spécifique a Lubuntu (lxde)
-if [ "$(which pcmanfm)" = "/usr/bin/pcmanfm" ] ; then
-  apt-get -y purge abiword gnumeric pidgin transmission-gtk sylpheed audacious guvcview ;
-fi
-
 ########################################################################
 #Paramétrage pour remplir pam_mount.conf
 ########################################################################
@@ -411,16 +401,6 @@ echo "enabled=0" > /etc/default/apport
 #suppression de l'applet network-manager
 ########################################################################
 mv /etc/xdg/autostart/nm-applet.desktop /etc/xdg/autostart/nm-applet.old
-
-########################################################################
-#suppression du menu messages
-########################################################################
-apt-get -y purge indicator-messages 
-
-
-# Lecture DVD
-apt-get -y install libdvdread4
-bash /usr/share/doc/libdvdread4/install-css.sh
 
 ########################################################################
 #nettoyage station avant clonage

--- a/ubuntu-et-variantes-postinstall.sh
+++ b/ubuntu-et-variantes-postinstall.sh
@@ -17,20 +17,20 @@ fi
 # Vérification que le système est a jour
 apt-get update ; apt-get -y dist-upgrade
 
+
 #########################################
 # Paquet uniquement pour la 14.04 / 17.3
 #########################################
 if [ "$DISTRIB_RELEASE" = "14.04" ] || [ "$DISTRIB_RELEASE" = "17.3" ] ; then
 
-# paquet
-apt-get -y install idle-python3.4 gstreamer0.10-plugins-ugly celestia
+    apt-get -y install idle-python3.4 gstreamer0.10-plugins-ugly celestia
 
-# Backportage LibreOffice
-add-apt-repository -y ppa:libreoffice/ppa ; apt-get update ; apt-get -y upgrade
+    # Backportage LibreOffice
+    add-apt-repository -y ppa:libreoffice/ppa ; apt-get update ; apt-get -y upgrade
 
-# Pour Google Earth : #(cette méthode ne fonctionne pas sur la 16.04)
-apt-get -y install libfontconfig1:i386 libx11-6:i386 libxrender1:i386 libxext6:i386 libgl1-mesa-glx:i386 libglu1-mesa:i386 libglib2.0-0:i386 libsm6:i386
-wget https://dl.google.com/dl/earth/client/current/google-earth-stable_current_i386.deb ; dpkg -i google-earth-stable_current_i386.deb ; apt-get -fy install ; rm -f google-earth-stable_current_i386.deb 
+    # Pour Google Earth : #(cette méthode ne fonctionne pas sur la 16.04)
+    apt-get -y install libfontconfig1:i386 libx11-6:i386 libxrender1:i386 libxext6:i386 libgl1-mesa-glx:i386 libglu1-mesa:i386 libglib2.0-0:i386 libsm6:i386
+    wget https://dl.google.com/dl/earth/client/current/google-earth-stable_current_i386.deb ; dpkg -i google-earth-stable_current_i386.deb ; apt-get -fy install ; rm -f google-earth-stable_current_i386.deb 
 
 fi
 
@@ -38,11 +38,9 @@ fi
 # Paquet uniquement pour la 16.04 / 18
 #########################################
 if [ "$DISTRIB_RELEASE" = "16.04" ] || [ "$DISTRIB_RELEASE" = "18" ] ; then
+    apt-get -y install idle-python3.5 x265 ;
 
-# paquet
-apt-get -y install idle-python3.5 x265 ;
-# méthode d'installation alternative pour Google Earth ? pour Celestia ? 
-
+    # méthode d'installation alternative pour Google Earth ? pour Celestia ? 
 fi
 
 #=======================================================================================================#
@@ -53,7 +51,9 @@ fi
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | /usr/bin/debconf-set-selections | apt-get -y install ttf-mscorefonts-installer ;
 
 # Oracle Java 8
-add-apt-repository -y ppa:webupd8team/java ; apt-get update ; echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections | apt-get -y install oracle-java8-installer
+add-apt-repository -y ppa:webupd8team/java ;
+apt-get update ;
+echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections | apt-get -y install oracle-java8-installer
 
 #[ Bureautique ]
 apt-get -y install libreoffice libreoffice-gtk libreoffice-l10n-fr freeplane scribus gnote xournal cups-pdf
@@ -92,9 +92,8 @@ apt-get -y install scratch ghex geany imagemagick
 ################################
 if [ "$(which unity)" = "/usr/bin/unity" ] ; then  # si Ubuntu/Unity alors :
 
-#[ Paquet AddOns ]
-apt-get -y install ubuntu-restricted-extras ubuntu-restricted-addons unity-tweak-tool
-apt-get -y install nautilus-image-converter nautilus-script-audio-convert
+    apt-get -y install ubuntu-restricted-extras ubuntu-restricted-addons unity-tweak-tool
+    apt-get -y install nautilus-image-converter nautilus-script-audio-convert
 
 fi
 
@@ -103,19 +102,21 @@ fi
 ################################
 if [ "$(which xfwm4)" = "/usr/bin/xfwm4" ] && [ "$DISTRIB_RELEASE" = "14.04" ] ; then # si Xubuntu/Xfce 14.04 alors :
 
-#[ Paquet AddOns ]
-apt-get -y install xubuntu-restricted-extras xubuntu-restricted-addons xfce4-goodies xfwm4-themes
+    #[ Paquet AddOns ]
+    apt-get -y install xubuntu-restricted-extras xubuntu-restricted-addons xfce4-goodies xfwm4-themes
 
-# Customisation XFCE
+    # Customisation XFCE
 
-add-apt-repository -y ppa:docky-core/stable ; apt-get update ; apt-get -y install plank ;
-wget --no-check-certificate https://dane.ac-lyon.fr/spip/IMG/tar/skel_xub1404.tar ; tar xvf skel_xub1404.tar -C /etc ; rm -rf skel_xub1404.tar
+    add-apt-repository -y ppa:docky-core/stable ; apt-get update ; apt-get -y install plank ;
+    wget --no-check-certificate https://dane.ac-lyon.fr/spip/IMG/tar/skel_xub1404.tar ; tar xvf skel_xub1404.tar -C /etc ; rm -rf skel_xub1404.tar
 fi
 
 if [ "$(which xfwm4)" = "/usr/bin/xfwm4" ] && [ "$DISTRIB_RELEASE" = "16.04" ] ; then # si Xubuntu/Xfce 16.04 alors :
 
-#[ Paquet AddOns ]
-apt-get -y install xubuntu-restricted-extras xubuntu-restricted-addons xfce4-goodies xfwm4-themes
+    #[ Paquet AddOns ]
+    apt-get -y install xubuntu-restricted-extras xubuntu-restricted-addons xfce4-goodies xfwm4-themes
+
+    # pas de customisation pour XFCE?
 
 fi
 
@@ -124,11 +125,12 @@ fi
 ################################
 if [ "$(which caja)" = "/usr/bin/caja" ] && [ "$DISTRIB_RELEASE" = "16.04" ] ; then # si Ubuntu Mate 16.04 alors :
 
-#paquet
-apt-get -y install ubuntu-restricted-extras mate-desktop-enivonment-extras
+    #paquet
+    apt-get -y install ubuntu-restricted-extras mate-desktop-enivonment-extras
 
-# Customisation Mate
-# Mettre 1 skel spécifique a Mate ?
+    apt-get -y purge hexchat transmission-gtk ubuntu-mate-welcome cheese pidgin rhythmbox ;
+    # Customisation Mate
+    # Mettre 1 skel spécifique a Mate ?
 
 fi
 
@@ -137,9 +139,18 @@ fi
 ################################
 if [ "$(which pcmanfm)" = "/usr/bin/pcmanfm" ] ; then  # si Lubuntu / Lxde alors :
 
-#[ Paquet AddOns ]
-apt-get -y install lubuntu-restricted-extras lubuntu-restricted-addons
+    apt-get -y purge abiword gnumeric pidgin transmission-gtk sylpheed audacious guvcview ;
+
+    #[ Paquet AddOns ]
+    apt-get -y install lubuntu-restricted-extras lubuntu-restricted-addons
 fi
+
+
+################################
+# Lecture DVD
+################################
+apt-get -y install libdvdread4
+bash /usr/share/doc/libdvdread4/install-css.sh
 
 ########################################################################
 #nettoyage station 


### PR DESCRIPTION
Bonjour,

J'ai déplacé tout ce qui concernait l'instalation de paquet (sans lien avec l'integration au domaine) de integrdom vers postinstall.
De cette façon, on peut utiliser le script postinstall pour préparer des machines qui ne seront pas connectée au réseau.
